### PR TITLE
Update nl.m3u

### DIFF
--- a/nl/nl.m3u
+++ b/nl/nl.m3u
@@ -315,8 +315,8 @@ http://mediaserv30.live-streams.nl:8007/stream
 https://icecast-qmusicnl-cdp.triple-it.nl/Joe_nl_1_96.mp3
 #EXTINF:-1 tvg-logo="" group-title="",Joy Radio
 http://stream.joyradio.nl/joyradio
-#EXTINF:-1 tvg-logo="" group-title="drum and bass,jungle",Jungletrain.net
-http://stream5.jungletrain.net:8000/
+#EXTINF:-1 tvg-logo="https://jungletrain.net/images/logo_final_003_wyb_.svg" group-title="drum and bass,jungle",Jungletrain.net [128Kbps MP3]
+https://jungletrain.net/128kbps.pls
 #EXTINF:-1 tvg-logo="" group-title="80s,pop",Keizerstad Radio 80s
 http://server-06.stream-server.nl:8800/
 #EXTINF:-1 tvg-logo="https://kink.nl/static/apple-touch-icon.png" group-title="",KINK


### PR DESCRIPTION
Fixed stream URL on Jungletrain.net to; and added a logo.

`https://jungletrain.net/128kbps.pls`

128kbps.pls contants 3 URLs at different server locations, This might be down to;

1) If the server is maxed out of listeners, The next one will be a backup.
2) Geolocation Filter (Routing Filter containing users that are located within an area)